### PR TITLE
Spin up Consul dependency for service

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "example-consul"]
+	path = example-consul
+	url = https://github.com/getcloudless/example-consul

--- a/blueprint.yml
+++ b/blueprint.yml
@@ -19,8 +19,10 @@ image:
   name: "cloudless-example-base-image-v0"
 
 initialization:
-  - path: "apache_startup_script.sh"
+  - path: "static_site_startup_script.sh"
     vars:
+      consul_ips:
+        required: true
       cloudless_test_framework_ssh_key:
         required: false
       cloudless_test_framework_ssh_username:

--- a/blueprint_fixture.py
+++ b/blueprint_fixture.py
@@ -4,10 +4,10 @@ Static Site Test Fixture
 import os
 from retrying import retry
 import requests
+import consul
 from cloudless.testutils.blueprint_tester import call_with_retries
 from cloudless.testutils.fixture import BlueprintTestInterface, SetupInfo
 from cloudless.types.networking import CidrBlock
-import consul
 
 SERVICE_BLUEPRINT = os.path.join(os.path.dirname(__file__), "example-consul/blueprint.yml")
 
@@ -32,7 +32,7 @@ class BlueprintTest(BlueprintTestInterface):
             assert public_ips, "No services are running..."
             for public_ip in public_ips:
                 consul_client = consul.Consul(public_ip)
-                if consul_client.kv.get('dummy_api_key'):
+                if consul_client.kv.get('dummy_api_key')[1]:
                     continue
                 consul_client.kv.put('dummy_api_key', 'dummy_api_key_value')
             return True

--- a/blueprint_fixture.py
+++ b/blueprint_fixture.py
@@ -1,13 +1,15 @@
 """
-Apache Test Fixture
-
-This fixture doesn't do any setup, but verifies that the created service is
-running default apache.
+Static Site Test Fixture
 """
+import os
+from retrying import retry
 import requests
 from cloudless.testutils.blueprint_tester import call_with_retries
 from cloudless.testutils.fixture import BlueprintTestInterface, SetupInfo
 from cloudless.types.networking import CidrBlock
+import consul
+
+SERVICE_BLUEPRINT = os.path.join(os.path.dirname(__file__), "example-consul/blueprint.yml")
 
 RETRY_DELAY = float(10.0)
 RETRY_COUNT = int(6)
@@ -20,16 +22,44 @@ class BlueprintTest(BlueprintTestInterface):
         """
         Create the dependent services needed to test this service.
         """
-        # Since this service has no dependencies, do nothing.
-        return SetupInfo({}, {})
+        # Create consul since our web server needs it to pull API keys.
+        service_name = "consul"
+        service = self.client.service.create(network, service_name, SERVICE_BLUEPRINT, count=1)
+
+        @retry(wait_fixed=5000, stop_max_attempt_number=24)
+        def add_dummy_api_keys(service):
+            public_ips = [i.public_ip for s in service.subnetworks for i in s.instances]
+            assert public_ips, "No services are running..."
+            for public_ip in public_ips:
+                consul_client = consul.Consul(public_ip)
+                if consul_client.kv.get('dummy_api_key'):
+                    continue
+                consul_client.kv.put('dummy_api_key', 'dummy_api_key_value')
+            return True
+
+        # Now let's add some dummy API keys to Consul.
+        my_ip = requests.get("http://ipinfo.io/ip")
+        test_machine = CidrBlock(my_ip.content.decode("utf-8").strip())
+        self.client.paths.add(test_machine, service, 8500)
+        add_dummy_api_keys(service)
+        self.client.paths.remove(test_machine, service, 8500)
+
+        return SetupInfo(
+            {"service_name": service_name},
+            {"consul_ips": [i.private_ip for s in service.subnetworks for i in s.instances]})
 
     def setup_after_tested_service(self, network, service, setup_info):
         """
         Do any setup that must happen after the service under test has been
         created.
         """
-        internet = CidrBlock("0.0.0.0/0")
-        self.client.paths.add(internet, service, 80)
+        consul_service_name = setup_info.deployment_info["service_name"]
+        consul_service = self.client.service.get(network, consul_service_name)
+        my_ip = requests.get("http://ipinfo.io/ip")
+        test_machine = CidrBlock(my_ip.content.decode("utf-8").strip())
+        self.client.paths.add(service, consul_service, 8500)
+        self.client.paths.add(test_machine, service, 80)
+        self.client.paths.add(test_machine, service, 443)
 
     def verify(self, network, service, setup_info):
         """

--- a/static_site_startup_script.sh
+++ b/static_site_startup_script.sh
@@ -8,9 +8,13 @@ echo "{{ cloudless_test_framework_ssh_key }}" >> /home/{{ cloudless_test_framewo
 {% endif %}
 
 apt-get update
-apt-get install -y apache2
-cat <<EOF > /var/www/html/index.html
-<html><body><h1>Hello World</h1>
-<p>This page was created from a simple startup script!</p>
-</body></html>
+apt-get install -y python3-pip
+pip install python-consul
+cat <<EOF > /tmp/fetch_key.py
+import consul
+consul_client = consul.Consul("{{ consul_ips[0] }}")
+dummy_api_key = consul_client.kv.get('dummy_api_key')
+print(dummy_api_key[1]["Value"].decode("utf-8").strip()
 EOF
+
+python /tmp/fetch_key.py >> /tmp/dummy_key.txt

--- a/static_site_startup_script.sh
+++ b/static_site_startup_script.sh
@@ -9,12 +9,12 @@ echo "{{ cloudless_test_framework_ssh_key }}" >> /home/{{ cloudless_test_framewo
 
 apt-get update
 apt-get install -y python3-pip
-pip install python-consul
+pip3 install python-consul
 cat <<EOF > /tmp/fetch_key.py
 import consul
 consul_client = consul.Consul("{{ consul_ips[0] }}")
 dummy_api_key = consul_client.kv.get('dummy_api_key')
-print(dummy_api_key[1]["Value"].decode("utf-8").strip()
+print(dummy_api_key[1]["Value"].decode("utf-8").strip())
 EOF
 
-python /tmp/fetch_key.py >> /tmp/dummy_key.txt
+python3 /tmp/fetch_key.py >> /tmp/dummy_key.txt


### PR DESCRIPTION
This creates a Consul server and adds a dummy key as part of a test run, so that we can ensure the configuration on the web server that needs to talk to Consul works properly.