### PR TITLE
Clean up Pipfile and use pypi version of cloudless

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .cloudless
+Pipfile.lock

--- a/Pipfile
+++ b/Pipfile
@@ -1,2 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[dev-packages]
+
 [packages]
-cloudless = {git = "https://github.com/sverch/cloudless", ref = "master", editable = true}
+cloudless = "*"
+
+[requires]
+python_version = "3.6"


### PR DESCRIPTION
Before I was just referencing github, but to be a better example this uses the actual python package.