### PR TITLE
Setup https using sslmate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,27 @@
-# Apache Service Example
+# Static Site Service Example
 
-This is an example of creating a service running Apache.  Note that this
+This is an example of creating a service running a static site.  Note that this
 blueprint references an image created by the base image scripts at
 [https://github.com/getcloudless/example-base-image](https://github.com/getcloudless/example-base-image),
 so this will fail unless you run that first.
 
 ## Usage
 
-The file at `blueprint.yml` can be used in any service command:
+The file at `blueprint.yml` can be used in any service command, and you need to
+pass in a `vars.yml` that minimally sets `consul_ips`, `jekyll_site_domain`, and
+`jekyll_site_github_url`. Here's an example vars file:
 
 ```
-cldls service create blueprint.yml
+---
+consul_ips: ["10.0.0.1"]
+jekyll_site_domain: "getcloudless.com"
+jekyll_site_github_url: "https://github.com/getcloudless/getcloudless.com/"
+```
+
+And here's the service creation:
+
+```
+cldls service create blueprint.yml vars.yml
 ```
 
 You can run the service's regression tests with:
@@ -23,7 +34,21 @@ Note that these are completely independent of what provider you're using,
 assuming you've already built the [Base
 Image](https://github.com/getcloudless/example-base-image).
 
-## Workflow
+## SSL Support
+
+This module uses [sslmate](https://sslmate.com/) to configure https.
+
+If you want the regression test to use SSL, you need to set `SSLMATE_API_KEY`,
+`SSLMATE_API_ENDPOINT`, and `SSLMATE_PRIVATE_KEY_PATH` to the proper values.
+It's recommended that you use the [sslmate
+sandbox](https://sslmate.com/help/sandbox) for this.
+
+If you want to use SSL, you need to set `use_sslmate` to true in your `vars.yml`
+file, and then set `SSLMATE_API_KEY`, `SSLMATE_API_ENDPOINT`, and
+`{your_domain}.key` to the proper values on the Consul server that you provide
+in `consul_ips`.
+
+## Development
 
 The main value of the test framework is that it is focused on the workflow of
 actually developing a service.  For example, if you want to deploy a service
@@ -51,14 +76,3 @@ cldls service-test cleanup service_test_configuration.yml
 ```
 
 You're done!  The run step will run all these steps in order.
-
-## Files
-
-- `service_test_configuration.yml`: Configuration file for the service test
-  framework.
-- `blueprint.yml`: Blueprint that is actually used to create the service.  This
-  is the thing we are really testing.
-- `apache_startup_script.sh`: Script referenced by the blueprint that will set
-  up Apache.
-- `blueprint_fixture.py`: Python test fixture that will set up dependencies and
-  verify that things are behaving as expected.

--- a/blueprint.yml
+++ b/blueprint.yml
@@ -21,10 +21,14 @@ image:
 initialization:
   - path: "static_site_startup_script.sh"
     vars:
+      jekyll_site_domain:
+        required: true
       jekyll_site_github_url:
         required: true
       consul_ips:
         required: true
+      use_sslmate:
+        required: false
       cloudless_test_framework_ssh_key:
         required: false
       cloudless_test_framework_ssh_username:

--- a/blueprint_fixture.py
+++ b/blueprint_fixture.py
@@ -26,28 +26,39 @@ class BlueprintTest(BlueprintTestInterface):
         service_name = "consul"
         service = self.client.service.create(network, service_name, SERVICE_BLUEPRINT, count=1)
 
+        use_sslmate = 'SSLMATE_API_KEY' in os.environ
+
         @retry(wait_fixed=5000, stop_max_attempt_number=24)
-        def add_dummy_api_keys(service):
+        def add_api_keys(service):
             public_ips = [i.public_ip for s in service.subnetworks for i in s.instances]
             assert public_ips, "No services are running..."
             for public_ip in public_ips:
                 consul_client = consul.Consul(public_ip)
-                if consul_client.kv.get('dummy_api_key')[1]:
-                    continue
-                consul_client.kv.put('dummy_api_key', 'dummy_api_key_value')
+                if use_sslmate:
+                    consul_client.kv.put('SSLMATE_API_KEY', os.environ['SSLMATE_API_KEY'])
+                    consul_client.kv.put('SSLMATE_API_ENDPOINT', os.environ['SSLMATE_API_ENDPOINT'])
+                    consul_client.kv.put('getcloudless.com.key',
+                                         open(os.environ['SSLMATE_PRIVATE_KEY_PATH']).read())
             return True
 
-        # Now let's add some dummy API keys to Consul.
+        # Now let's add any necessary API keys to Consul.
         my_ip = requests.get("http://ipinfo.io/ip")
         test_machine = CidrBlock(my_ip.content.decode("utf-8").strip())
         self.client.paths.add(test_machine, service, 8500)
-        add_dummy_api_keys(service)
+        add_api_keys(service)
         self.client.paths.remove(test_machine, service, 8500)
+
+        blueprint_variables = {
+            "consul_ips": [i.private_ip for s in service.subnetworks for i in s.instances],
+            "jekyll_site_github_url": "https://github.com/getcloudless/getcloudless.com.git",
+            "jekyll_site_domain": "getcloudless.com"}
+
+        if use_sslmate:
+            blueprint_variables["use_sslmate"] = True
 
         return SetupInfo(
             {"service_name": service_name},
-            {"consul_ips": [i.private_ip for s in service.subnetworks for i in s.instances],
-             "jekyll_site_github_url": "https://github.com/getcloudless/getcloudless.com.git"})
+            blueprint_variables)
 
     def setup_after_tested_service(self, network, service, setup_info):
         """
@@ -67,11 +78,17 @@ class BlueprintTest(BlueprintTestInterface):
         Given the network name and the service name of the service under test,
         verify that it's behaving as expected.
         """
+        use_sslmate = ("use_sslmate" in setup_info.blueprint_vars and
+                       setup_info.blueprint_vars["use_sslmate"])
         def check_responsive():
             public_ips = [i.public_ip for s in service.subnetworks for i in s.instances]
             assert public_ips
             for public_ip in public_ips:
-                response = requests.get("http://%s" % public_ip)
+                if use_sslmate:
+                    # Don't verify the certificate so we can test using the sslmate sandbox
+                    response = requests.get("https://%s" % public_ip, verify=False)
+                else:
+                    response = requests.get("http://%s" % public_ip)
                 expected_content = "Cloudless"
                 assert response.content, "No content in response"
                 assert expected_content in str(response.content), (

--- a/static_site_startup_script.sh
+++ b/static_site_startup_script.sh
@@ -10,22 +10,127 @@ mkdir /home/{{ cloudless_test_framework_ssh_username }}/.ssh/
 echo "{{ cloudless_test_framework_ssh_key }}" >> /home/{{ cloudless_test_framework_ssh_username }}/.ssh/authorized_keys
 {% endif %}
 
+# STATIC SECTION: This section has all things that should probably be baked into
+# the image or built as containers or something.
+
+# Update Packages
 apt-get update
+
+# Install Base Packages
+apt-get install -y nginx git
+
+# Install Bundler for Jekyll
+apt-get install -y ruby-dev build-essential zlib1g-dev
+gem install bundler
+
+# Install Python Script to Pull from Consul
 apt-get install -y python3-pip
 pip3 install python-consul
 cat <<EOF > /tmp/fetch_key.py
+import sys
 import consul
 consul_client = consul.Consul("{{ consul_ips[0] }}")
-dummy_api_key = consul_client.kv.get('dummy_api_key')
+dummy_api_key = consul_client.kv.get(sys.argv[1])
 print(dummy_api_key[1]["Value"].decode("utf-8").strip())
 EOF
 
-python3 /tmp/fetch_key.py >> /tmp/dummy_key.txt
+# Install sslmate (https://sslmate.com/help/cmdline/install)
+wget -P /etc/apt/sources.list.d https://sslmate.com/apt/ubuntu1804/sslmate1.list
+wget -P /etc/apt/trusted.gpg.d https://sslmate.com/apt/ubuntu1804/sslmate.gpg
+apt-get update
+apt-get install -y sslmate
+mkdir -p /etc/sslmate
 
-apt-get install -y nginx git ruby-dev build-essential zlib1g-dev
+# DYNAMIC SECTION: This section has all the blocks that take template variables
+# or should probably happen at runtime.  This could be done by having
+# configuration scripts built into the image (for example, a "configure nginx"
+# script that has some defaults set).  As is, these could not be built into the
+# base image.
+
+{% if use_sslmate %}
+# Install sslmate certificate download script
+cat <<EOF > /opt/sslmate_download.sh
+cd /etc/sslmate/
+export SSLMATE_CONFIG=/etc/sslmate.conf
+if sslmate download {{ jekyll_site_domain }}
+then
+    service nginx restart
+fi
+EOF
+chmod a+x /opt/sslmate_download.sh
+{% endif %}
+
+# Configure Nginx
+cat <<EOF >| /etc/nginx/sites-available/getcloudless.com.conf
+server {
+{% if use_sslmate %}
+    listen 80 default_server;
+    listen [::]:80 default_server;
+
+    server_name _;
+
+    return 301 https://\$host\$request_uri;
+}
+
+server {
+    listen 443 ssl default_server;
+    listen [::]:443 ssl default_server;
+    ssl_certificate_key /etc/sslmate/getcloudless.com.key;
+    ssl_certificate /etc/sslmate/getcloudless.com.chained.crt;
+
+    # Recommended security settings from https://wiki.mozilla.org/Security/Server_Side_TLS
+    ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
+    ssl_dhparam /usr/share/sslmate/dhparams/dh2048-group14.pem;
+    ssl_session_timeout 5m;
+    ssl_session_cache shared:SSL:5m;
+    # Enable this if you want HSTS (recommended)
+    add_header Strict-Transport-Security max-age=15768000;
+{% else %}
+    listen 80 default_server;
+    listen [::]:80 default_server;
+{% endif %}
+
+    root /var/www/html;
+
+    index index.html index.htm
+
+    server_name _;
+
+    location / {
+        # First attempt to serve request as file, then
+        # as directory, then fall back to displaying a 404.
+        try_files \$uri \$uri/ =404;
+    }
+}
+EOF
+ln -s /etc/nginx/sites-available/getcloudless.com.conf \
+      /etc/nginx/sites-enabled/getcloudless.com.conf
+rm /etc/nginx/sites-enabled/default
+
+# Build Jekyll Site
 echo Cloning: "{{ jekyll_site_github_url }}"
 git clone "{{ jekyll_site_github_url }}"
-gem install bundler
-cd getcloudless.com/
+cd getcloudless.com/ || exit
 bundle install
 bundle exec jekyll build --destination /var/www/html
+
+{% if use_sslmate %}
+# Configure sslmate
+cat <<EOF >| /etc/sslmate.conf
+api_key $(python3 /tmp/fetch_key.py SSLMATE_API_KEY)
+api_endpoint $(python3 /tmp/fetch_key.py SSLMATE_API_ENDPOINT)
+EOF
+
+# Fetch ssl private key first so sslmate can check that it's correct
+python3 /tmp/fetch_key.py "{{ jekyll_site_domain }}.key" >> "/etc/sslmate/{{ jekyll_site_domain }}.key"
+
+# Download ssl certificates
+/opt/sslmate_download.sh
+
+# Install certificate download as a cron job
+# (https://stackoverflow.com/a/16068840)
+(crontab -l ; echo "0 1 * * * /opt/sslmate_download.sh") | crontab -
+{% endif %}
+
+# Restart nginx
+service nginx restart


### PR DESCRIPTION
This adds https support using certificates from sslmate, with auto renewal. The test framework will automatically configure the Consul server correctly if you have the right environment variables set. See README.md for more details.