### PR TITLE
Add consul health check and regression test

### DIFF
--- a/blueprint_fixture.py
+++ b/blueprint_fixture.py
@@ -151,3 +151,15 @@ class BlueprintTest(BlueprintTestInterface):
                 del datapoint['pointlist']
             assert False, "No nginx stats in datadog metrics for this service!  %s" % series
         call_with_retries(is_agent_sending_nginx_metrics, RETRY_COUNT, RETRY_DELAY)
+
+        def is_agent_sending_consul_metrics():
+            now = int(time.time())
+            query = 'consul.catalog.total_nodes{*}by{host}'
+            series = api.Metric.query(start=now - 600, end=now, query=query)
+            for datapoint in series['series']:
+                if re.match(".*%s.*%s.*" % (network.name, service.name), datapoint['expression']):
+                    return
+                # Delete this because we don't care about it here and it muddies the error message
+                del datapoint['pointlist']
+            assert False, "No consul stats in datadog metrics for this service!  %s" % series
+        call_with_retries(is_agent_sending_consul_metrics, RETRY_COUNT, RETRY_DELAY)

--- a/static_site_startup_script.sh
+++ b/static_site_startup_script.sh
@@ -163,6 +163,14 @@ init_config:
 instances:
   - nginx_status_url: http://localhost:81/nginx_status/
 EOF
+cat <<EOF >| /etc/datadog-agent/conf.d/consul.d/conf.yaml
+init_config:
+instances:
+  - url: http://{{ consul_ips[0] }}:8500
+    catalog_checks: true
+    self_leader_check: true
+    network_latency_checks: true
+EOF
 systemctl start datadog-agent
 {% endif %}
 


### PR DESCRIPTION
This ensures that the web servers are checking the consul service to see if it's up, so we can set up alerts for a failing consul service.