### PR TITLE
Add script to wait for Consul to be available

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,10 +4,12 @@ verify_ssl = true
 name = "pypi"
 
 [dev-packages]
+pylint = "*"
 
 [packages]
 cloudless = "*"
 python-consul = "*"
+datadog = "*"
 
 [requires]
 python_version = "3.6"

--- a/blueprint_fixture.py
+++ b/blueprint_fixture.py
@@ -77,9 +77,11 @@ class BlueprintTest(BlueprintTestInterface):
         consul_service = self.client.service.get(network, consul_service_name)
         my_ip = requests.get("http://ipinfo.io/ip")
         test_machine = CidrBlock(my_ip.content.decode("utf-8").strip())
-        self.client.paths.add(service, consul_service, 8500)
         self.client.paths.add(test_machine, service, 80)
         self.client.paths.add(test_machine, service, 443)
+        # Add this last because we want to make sure that our service can handle a delay before
+        # getting connectivity to consul.
+        self.client.paths.add(service, consul_service, 8500)
 
     def verify(self, network, service, setup_info):
         """


### PR DESCRIPTION
This allows us to tolerate a 10 minute delay between when we spin up the service and when we grant firewall access to Consul, which seems reasonable.

Eventually, this kind of thing would be its own separate "agent" that comes with its own unit tests, but for now this is just an example of how to glue things together with Cloudless.

Fixes: https://github.com/getcloudless/example-static-site/issues/8