### PR TITLE
Fix hardcoded domain issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .cloudless
 Pipfile.lock
+example-environment.sh

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ By default, the tests assume the certificate is for `getcloudless.com` (which
 you can get by using the SSLMate sandbox).  If you want to test that your domain
 works, set the `STATIC_SITE_TEST_DOMAIN` environment variable.
 
+See `example-environment.sh` for how to set these.
+
 If you want to use SSL when you deploy, you need to set `use_sslmate` to true in
 your `vars.yml` file, and then set `SSLMATE_API_KEY`, `SSLMATE_API_ENDPOINT`,
 and `{your_domain}.key` to the proper values on the Consul server that you
@@ -61,6 +63,8 @@ If you want the regression test to test for this, you need to set
 `DATADOG_API_KEY` is the same one use use for the agent while the
 `DATADOG_APP_KEY` identifies the client (the machine running Cloudless) that's
 querying the DataDog API to test whether the service is logging.
+
+See `example-environment.sh` for how to set these.
 
 If you want to set up monitoring, you need to set `use_datadog` to true in your
 `vars.yml` file, and then set `DATADOG_API_KEY` and `DATADOG_APP_KEY` to the

--- a/README.md
+++ b/README.md
@@ -43,10 +43,14 @@ If you want the regression test to use SSL, you need to set `SSLMATE_API_KEY`,
 It's recommended that you use the [sslmate
 sandbox](https://sslmate.com/help/sandbox) for this.
 
-If you want to use SSL, you need to set `use_sslmate` to true in your `vars.yml`
-file, and then set `SSLMATE_API_KEY`, `SSLMATE_API_ENDPOINT`, and
-`{your_domain}.key` to the proper values on the Consul server that you provide
-in `consul_ips`.
+By default, the tests assume the certificate is for `getcloudless.com` (which
+you can get by using the SSLMate sandbox).  If you want to test that your domain
+works, set the `STATIC_SITE_TEST_DOMAIN` environment variable.
+
+If you want to use SSL when you deploy, you need to set `use_sslmate` to true in
+your `vars.yml` file, and then set `SSLMATE_API_KEY`, `SSLMATE_API_ENDPOINT`,
+and `{your_domain}.key` to the proper values on the Consul server that you
+provide in `consul_ips`.
 
 ## DataDog Monitoring
 

--- a/example-environment.sh
+++ b/example-environment.sh
@@ -1,0 +1,12 @@
+# This file shows an example of some of the environment variables that can be
+# used to configure the test behavior.
+
+#export SSLMATE_API_KEY="<key>"
+#export SSLMATE_API_ENDPOINT=https://sandbox.sslmate.com/api/v2
+#export DATADOG_API_KEY="<key>"
+#export DATADOG_APP_KEY="<key>"
+#export NSONE_CLOUDLESS_API_KEY="<key>"
+
+# Change what domain you are testing.  This is the default.
+export STATIC_SITE_TEST_DOMAIN="getcloudless.com"
+export SSLMATE_PRIVATE_KEY_PATH="getcloudless.com.key"

--- a/static_site_startup_script.sh
+++ b/static_site_startup_script.sh
@@ -88,7 +88,7 @@ apt-get install -y datadog-agent
 cat <<EOF > /opt/sslmate_download.sh
 cd /etc/sslmate/
 export SSLMATE_CONFIG=/etc/sslmate.conf
-if sslmate download {{ jekyll_site_domain }}
+if sslmate download "{{ jekyll_site_domain }}"
 then
     service nginx restart
 fi
@@ -97,7 +97,7 @@ chmod a+x /opt/sslmate_download.sh
 {% endif %}
 
 # Configure Nginx
-cat <<EOF >| /etc/nginx/sites-available/getcloudless.com.conf
+cat <<EOF >| "/etc/nginx/sites-available/{{ jekyll_site_domain }}.conf"
 server {
 {% if use_sslmate %}
     listen 80 default_server;
@@ -111,8 +111,8 @@ server {
 server {
     listen 443 ssl default_server;
     listen [::]:443 ssl default_server;
-    ssl_certificate_key /etc/sslmate/getcloudless.com.key;
-    ssl_certificate /etc/sslmate/getcloudless.com.chained.crt;
+    ssl_certificate_key /etc/sslmate/{{ jekyll_site_domain }}.key;
+    ssl_certificate /etc/sslmate/{{ jekyll_site_domain }}.chained.crt;
 
     # Recommended security settings from https://wiki.mozilla.org/Security/Server_Side_TLS
     ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
@@ -139,14 +139,14 @@ server {
     }
 }
 EOF
-ln -s /etc/nginx/sites-available/getcloudless.com.conf \
-      /etc/nginx/sites-enabled/getcloudless.com.conf
+ln -s "/etc/nginx/sites-available/{{ jekyll_site_domain }}.conf" \
+      "/etc/nginx/sites-enabled/{{ jekyll_site_domain }}.conf"
 rm /etc/nginx/sites-enabled/default
 
 # Build Jekyll Site
 echo Cloning: "{{ jekyll_site_github_url }}"
-git clone "{{ jekyll_site_github_url }}"
-cd getcloudless.com/ || exit
+git clone "{{ jekyll_site_github_url }}" "{{ jekyll_site_domain }}"
+cd "{{ jekyll_site_domain }}" || exit
 bundle install
 bundle exec jekyll build --destination /var/www/html
 


### PR DESCRIPTION
getcloudless.com was hard coded in a bunch of places.  This fixes that
and makes the test domain configurable so that the tests could catch
this issue.

Also show an example of how to configure the tests.